### PR TITLE
fix(playground): use 'polkadot-js' discovery key for Vultisig

### DIFF
--- a/vultisig-playground/src/components/polkadot/InjectedWeb3Playground.tsx
+++ b/vultisig-playground/src/components/polkadot/InjectedWeb3Playground.tsx
@@ -61,11 +61,11 @@ function InjectedWeb3Playground({ onResult, onError }: InjectedWeb3PlaygroundPro
     setMethodLoading('enable', true)
     try {
       const injectedWeb3 = window.injectedWeb3
-      if (!injectedWeb3?.vultisig) {
-        onError('window.injectedWeb3.vultisig not found. Is the Vultisig extension installed?')
+      if (!injectedWeb3?.['polkadot-js']) {
+        onError("window.injectedWeb3['polkadot-js'] not found. Is the Vultisig extension installed?")
         return
       }
-      const provider = await injectedWeb3.vultisig.enable('vultisig-playground')
+      const provider = await injectedWeb3['polkadot-js'].enable('vultisig-playground')
       setEnabledProvider(provider)
       setMethodResult('enable', { success: true, hasAccounts: !!provider.accounts, hasSigner: !!provider.signer })
       onResult({ enabled: true, accounts: !!provider.accounts, signer: !!provider.signer })
@@ -183,7 +183,7 @@ function InjectedWeb3Playground({ onResult, onError }: InjectedWeb3PlaygroundPro
       <div className="border border-gray-200 rounded-lg p-4">
         <h4 className="text-sm font-semibold text-gray-900 mb-2">1. enable(origin)</h4>
         <p className="text-xs text-gray-500 mb-3">
-          Calls <code>window.injectedWeb3.vultisig.enable('vultisig-playground')</code> to get accounts and signer.
+          Calls <code>window.injectedWeb3['polkadot-js'].enable('vultisig-playground')</code> to get accounts and signer.
         </p>
         <button
           onClick={handleEnable}

--- a/vultisig-playground/src/hooks/useProviderMethods.ts
+++ b/vultisig-playground/src/hooks/useProviderMethods.ts
@@ -7,7 +7,7 @@ export function useProviderMethods(providerName: string) {
 
   useEffect(() => {
     if (providerName === 'polkadot') {
-      if (window.injectedWeb3?.vultisig) {
+      if (window.injectedWeb3?.['polkadot-js']) {
         setMethods(['injectedWeb3'])
       } else {
         setMethods([])

--- a/vultisig-playground/src/pages/ProviderPlayground.tsx
+++ b/vultisig-playground/src/pages/ProviderPlayground.tsx
@@ -23,7 +23,7 @@ function ProviderPlayground() {
   const getProviderInstance = (): unknown | null => {
     if (!provider) return null
     if (provider === 'polkadot') {
-      return window.injectedWeb3?.vultisig || null
+      return window.injectedWeb3?.['polkadot-js'] || null
     }
     if (!window.vultisig) return null
     if (provider === 'ton') {
@@ -39,7 +39,7 @@ function ProviderPlayground() {
       setError(null)
     } else if (provider === 'polkadot') {
       if (window.injectedWeb3) {
-        setError('window.injectedWeb3 detected, but vultisig provider is not available.')
+        setError("window.injectedWeb3 detected, but the 'polkadot-js' provider is not available.")
       } else {
         setError('window.injectedWeb3 not detected. Please install the Vultisig extension.')
       }

--- a/vultisig-playground/vercel.json
+++ b/vultisig-playground/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## Summary

Two fixes for the Polkadot tab of the playground:

### 1. Switch from `injectedWeb3.vultisig` → `injectedWeb3['polkadot-js']`

The branded `vultisig` key used to be exposed by the Vultisig extension but was **deliberately removed** in [vultisig-windows#3718](https://github.com/vultisig/vultisig-windows/pull/3718) to fix a bug on taostats where the same account appeared 4× in dApp account lists (because `@polkadot/extension-dapp` enumerates every `injectedWeb3` entry as a distinct extension).

Since that PR merged, the playground's Polkadot tab has shown:
> window.injectedWeb3 detected, but vultisig provider is not available.

This switches the playground to the standard `polkadot-js` key that the extension still exposes — the returned provider object is identical, so all existing playground logic (`enable`, `accounts.get`, `accounts.subscribe`, `signer.signPayload`, `signer.signRaw`) works unchanged.

### 2. Add `vercel.json` SPA rewrite so page refresh works

The app uses `BrowserRouter`. Refreshing any client-side route (e.g. `/polkadot/polkadot`) currently returns a Vercel 404 because the static file server can't find a matching file. A Netlify-style `public/_redirects` is already present but Vercel ignores it — the equivalent `vercel.json` rewrite is what Vercel actually reads.

## Changes

- `components/polkadot/InjectedWeb3Playground.tsx` — read `injectedWeb3['polkadot-js']` instead of `injectedWeb3.vultisig`
- `pages/ProviderPlayground.tsx` — same, plus updated error copy
- `hooks/useProviderMethods.ts` — same detection change
- `vercel.json` — SPA rewrite for Vercel

## Test plan

- [ ] Install the Vultisig extension with "Set Vultisig as default wallet" ON
- [ ] Open the Polkadot provider in the playground → "Enable" succeeds instead of showing the `not available` error
- [ ] `accounts.get()` returns the Polkadot account
- [ ] `signer.signPayload(...)` opens the popup and returns `{ id, signature }` with a `0x00`-prefixed ed25519 signature
- [ ] `signer.signRaw({ data: '0x48656c6c6f', type: 'bytes' })` also succeeds once [vultisig-windows#3758](https://github.com/vultisig/vultisig-windows/pull/3758) lands
- [ ] Deep-link to `/polkadot/polkadot` (or any other route) and hit refresh → page loads instead of showing a Vercel 404