### PR TITLE
fix(playground): replace THORChain RPC to avoid CORS preflight redirect

### DIFF
--- a/vultisig-playground/src/components/cosmos/cosmosUtils.ts
+++ b/vultisig-playground/src/components/cosmos/cosmosUtils.ts
@@ -9,7 +9,7 @@ export interface CosmosAccountInfo {
 export const getRpcUrl = (chainId: string): string => {
   const rpcMap: Record<string, string> = {
     'cosmoshub-4': 'https://cosmos-rpc.polkachu.com',
-    'thorchain-1': 'https://rpc.ninerealms.com',
+    'thorchain-1': 'https://rpc.thorchain.liquify.com',
   }
   return rpcMap[chainId] || `https://rpc.cosmos.directory/${chainId}`
 }


### PR DESCRIPTION
## Summary
- `https://rpc.ninerealms.com/` responds to the CORS preflight (`OPTIONS`) with a `301` redirect, which browsers refuse to follow per the CORS spec — blocking every request to the THORChain RPC from the playground.
- Switched `thorchain-1` in `getRpcUrl` to `https://rpc.thorchain.liquify.com`, which returns `204` with `Access-Control-Allow-Origin: *` directly on preflight (no redirect).

## Test plan
- [ ] Run the playground locally (`pnpm dev`), open the Cosmos section, select THORChain, and click Enable
- [ ] Verify no CORS error in the browser console and that `fetchCosmosAccountInfo` returns address / account number / sequence
- [ ] Confirm Cosmos Hub still works (unchanged endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)