### PR TITLE
feat(playground): add Cardano CIP-30 dApp tester

### DIFF
--- a/vultisig-playground/package-lock.json
+++ b/vultisig-playground/package-lock.json
@@ -19,6 +19,7 @@
         "@wallet-standard/base": "^1.1.0",
         "bchaddrjs": "^0.5.2",
         "buffer": "^6.0.3",
+        "cbor-x": "^1.6.0",
         "protobufjs": "^7.5.4",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -359,6 +360,84 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.2.tgz",
+      "integrity": "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.2.tgz",
+      "integrity": "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.2.tgz",
+      "integrity": "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.2.tgz",
+      "integrity": "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.2.tgz",
+      "integrity": "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.2.tgz",
+      "integrity": "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@cosmjs/amino": {
       "version": "0.37.0",
@@ -4106,6 +4185,37 @@
         "big-integer": "1.6.36"
       }
     },
+    "node_modules/cbor-extract": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.2.tgz",
+      "integrity": "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.1.1"
+      },
+      "bin": {
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-win32-x64": "2.2.2"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.4.tgz",
+      "integrity": "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "cbor-extract": "^2.2.2"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4441,7 +4551,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6376,6 +6486,21 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {

--- a/vultisig-playground/package.json
+++ b/vultisig-playground/package.json
@@ -21,6 +21,7 @@
     "@wallet-standard/base": "^1.1.0",
     "bchaddrjs": "^0.5.2",
     "buffer": "^6.0.3",
+    "cbor-x": "^1.6.0",
     "protobufjs": "^7.5.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/vultisig-playground/public/chains/ada.svg
+++ b/vultisig-playground/public/chains/ada.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <circle cx="16" cy="16" r="16" fill="#0033AD"/>
+  <g fill="#FFFFFF">
+    <circle cx="16" cy="5.8" r="1.1"/>
+    <circle cx="16" cy="26.2" r="1.1"/>
+    <circle cx="7.2" cy="10.9" r="1.1"/>
+    <circle cx="24.8" cy="10.9" r="1.1"/>
+    <circle cx="7.2" cy="21.1" r="1.1"/>
+    <circle cx="24.8" cy="21.1" r="1.1"/>
+    <circle cx="10.3" cy="8.6" r="0.75"/>
+    <circle cx="21.7" cy="8.6" r="0.75"/>
+    <circle cx="10.3" cy="23.4" r="0.75"/>
+    <circle cx="21.7" cy="23.4" r="0.75"/>
+    <circle cx="5.3" cy="16" r="0.75"/>
+    <circle cx="26.7" cy="16" r="0.75"/>
+    <circle cx="11.8" cy="13" r="1.35"/>
+    <circle cx="20.2" cy="13" r="1.35"/>
+    <circle cx="11.8" cy="19" r="1.35"/>
+    <circle cx="20.2" cy="19" r="1.35"/>
+    <circle cx="16" cy="9.8" r="1.35"/>
+    <circle cx="16" cy="22.2" r="1.35"/>
+    <circle cx="8.9" cy="16" r="1.35"/>
+    <circle cx="23.1" cy="16" r="1.35"/>
+    <circle cx="16" cy="16" r="2.1"/>
+  </g>
+</svg>

--- a/vultisig-playground/src/components/ChainMenu.tsx
+++ b/vultisig-playground/src/components/ChainMenu.tsx
@@ -26,6 +26,7 @@ const chains: Chain[] = [
   { id: 'DOT', name: 'Polkadot', icon: '/chains/dot.svg', path: '/dot', key: 'dot' },
   { id: 'DASH', name: 'Dash', icon: '/chains/dash.svg', path: '/dash', key: 'dash' },
   { id: 'TON', name: 'TON', icon: '/chains/ton.svg', path: '/ton', key: 'ton' },
+  { id: 'ADA', name: 'Cardano', icon: '/chains/ada.svg', path: '/ada', key: 'ada' },
 ]
 
 function ChainMenu() {

--- a/vultisig-playground/src/components/cardano/EnableMethod.tsx
+++ b/vultisig-playground/src/components/cardano/EnableMethod.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import type { CardanoCip30InitialApi, MethodComponentProps } from './types'
+import { formatCip30Error } from './cardanoUtils'
+
+export function EnableMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    const api = provider as CardanoCip30InitialApi
+    setLoading(true)
+    try {
+      const fullApi = await api.enable()
+      onResult({
+        connected: true,
+        availableMethods: Object.keys(fullApi).sort(),
+      })
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Requests connection to the wallet. First call shows the approval popup;
+        subsequent calls return the full CIP-30 API immediately.
+      </p>
+      <div className="bg-gray-50 border border-gray-200 rounded p-2 text-xs text-gray-700">
+        <span className="font-semibold">Wallet metadata:</span>{' '}
+        <code className="font-mono">
+          {JSON.stringify(
+            {
+              name: (provider as CardanoCip30InitialApi).name,
+              apiVersion: (provider as CardanoCip30InitialApi).apiVersion,
+              supportedExtensions: (provider as CardanoCip30InitialApi).supportedExtensions,
+            },
+            null,
+            2
+          )}
+        </code>
+      </div>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Enabling…' : 'Call enable()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/GetBalanceMethod.tsx
+++ b/vultisig-playground/src/components/cardano/GetBalanceMethod.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import type { MethodComponentProps } from './types'
+import {
+  decodeCardanoValue,
+  formatCip30Error,
+  formatLovelace,
+  getEnabledApi,
+} from './cardanoUtils'
+import { fromHex } from './cbor'
+
+export function GetBalanceMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      const cborHex = await api.getBalance()
+      const decoded = decodeCardanoValue(fromHex(cborHex))
+      onResult({
+        raw: cborHex,
+        lovelace: decoded.lovelace,
+        formatted: formatLovelace(BigInt(decoded.lovelace)),
+        assets: decoded.assets,
+      })
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Returns hex-encoded CBOR `Value` (lovelace + native assets). Decoded below for readability.
+      </p>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Fetching…' : 'Call getBalance()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/GetChangeAddressMethod.tsx
+++ b/vultisig-playground/src/components/cardano/GetChangeAddressMethod.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import type { MethodComponentProps } from './types'
+import { formatCip30Error, getEnabledApi } from './cardanoUtils'
+
+export function GetChangeAddressMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      const address = await api.getChangeAddress()
+      onResult({ addressHex: address })
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">Returns the hex-encoded change address for this wallet.</p>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Fetching…' : 'Call getChangeAddress()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/GetExtensionsMethod.tsx
+++ b/vultisig-playground/src/components/cardano/GetExtensionsMethod.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import type { MethodComponentProps } from './types'
+import { formatCip30Error, getEnabledApi } from './cardanoUtils'
+
+export function GetExtensionsMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      const extensions = await api.getExtensions()
+      onResult(extensions)
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Returns the list of active CIP-30 extensions the wallet has enabled.
+      </p>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Fetching…' : 'Call getExtensions()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/GetNetworkIdMethod.tsx
+++ b/vultisig-playground/src/components/cardano/GetNetworkIdMethod.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import type { MethodComponentProps } from './types'
+import { formatCip30Error, getEnabledApi } from './cardanoUtils'
+
+export function GetNetworkIdMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      const id = await api.getNetworkId()
+      onResult({ networkId: id, label: id === 1 ? 'mainnet' : id === 0 ? 'testnet' : 'unknown' })
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">Returns 1 for mainnet, 0 for testnet.</p>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Fetching…' : 'Call getNetworkId()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/GetRewardAddressesMethod.tsx
+++ b/vultisig-playground/src/components/cardano/GetRewardAddressesMethod.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import type { MethodComponentProps } from './types'
+import { formatCip30Error, getEnabledApi } from './cardanoUtils'
+
+export function GetRewardAddressesMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      const addresses = await api.getRewardAddresses()
+      onResult(addresses)
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Returns reward (stake) addresses. Vultisig returns an empty array (no staking support yet).
+      </p>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Fetching…' : 'Call getRewardAddresses()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/GetUnusedAddressesMethod.tsx
+++ b/vultisig-playground/src/components/cardano/GetUnusedAddressesMethod.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import type { MethodComponentProps } from './types'
+import { formatCip30Error, getEnabledApi } from './cardanoUtils'
+
+export function GetUnusedAddressesMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      const addresses = await api.getUnusedAddresses()
+      onResult(addresses)
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Returns hex-encoded addresses that have never received funds. Vultisig returns an empty array.
+      </p>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Fetching…' : 'Call getUnusedAddresses()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/GetUsedAddressesMethod.tsx
+++ b/vultisig-playground/src/components/cardano/GetUsedAddressesMethod.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import type { CardanoPaginate, MethodComponentProps } from './types'
+import { formatCip30Error, getEnabledApi } from './cardanoUtils'
+
+export function GetUsedAddressesMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+  const [page, setPage] = useState('')
+  const [limit, setLimit] = useState('')
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      let paginate: CardanoPaginate | undefined
+      if (page.trim() && limit.trim()) {
+        paginate = { page: Number(page), limit: Number(limit) }
+      }
+      const addresses = await api.getUsedAddresses(paginate)
+      onResult(addresses)
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Returns hex-encoded addresses that have been used (received funds). Optional pagination.
+      </p>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">Page (optional)</label>
+          <input
+            type="number"
+            min="0"
+            value={page}
+            onChange={(e) => setPage(e.target.value)}
+            placeholder="e.g. 0"
+            className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">Limit (optional)</label>
+          <input
+            type="number"
+            min="1"
+            value={limit}
+            onChange={(e) => setLimit(e.target.value)}
+            placeholder="e.g. 10"
+            className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Fetching…' : 'Call getUsedAddresses()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/GetUtxosMethod.tsx
+++ b/vultisig-playground/src/components/cardano/GetUtxosMethod.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import type { CardanoPaginate, MethodComponentProps } from './types'
+import {
+  decodeCardanoUtxo,
+  formatCip30Error,
+  formatLovelace,
+  getEnabledApi,
+  hexPreview,
+} from './cardanoUtils'
+import { fromHex } from './cbor'
+
+export function GetUtxosMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+  const [amount, setAmount] = useState('')
+  const [page, setPage] = useState('')
+  const [limit, setLimit] = useState('')
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      let paginate: CardanoPaginate | undefined
+      if (page.trim() && limit.trim()) {
+        paginate = { page: Number(page), limit: Number(limit) }
+      }
+      const utxos = await api.getUtxos(amount.trim() || undefined, paginate)
+
+      if (!utxos) {
+        onResult({ note: 'Wallet has no UTXOs (or insufficient for requested amount)', utxos: null })
+        return
+      }
+
+      const decoded = utxos.map((hex) => {
+        const u = decodeCardanoUtxo(fromHex(hex))
+        return {
+          raw: hexPreview(hex, 20),
+          txHash: u.txHash,
+          outputIndex: u.outputIndex,
+          address: hexPreview(u.address, 16),
+          lovelace: formatLovelace(BigInt(u.value.lovelace)),
+          assets: u.value.assets,
+        }
+      })
+      onResult({ count: utxos.length, utxos: decoded, rawHexes: utxos })
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Returns hex-encoded UTXOs. Optional `amount` (hex CBOR Value) for coin selection; optional pagination.
+      </p>
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">
+          Amount CBOR hex (optional)
+        </label>
+        <input
+          type="text"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="e.g. 1a00989680 (= 10 ADA lovelace-only)"
+          className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <p className="text-xs text-gray-500 mt-1">
+          Leave blank to return all UTXOs. Otherwise the wallet tries to coin-select a covering subset.
+        </p>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">Page (optional)</label>
+          <input
+            type="number"
+            min="0"
+            value={page}
+            onChange={(e) => setPage(e.target.value)}
+            placeholder="e.g. 0"
+            className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">Limit (optional)</label>
+          <input
+            type="number"
+            min="1"
+            value={limit}
+            onChange={(e) => setLimit(e.target.value)}
+            placeholder="e.g. 5"
+            className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Fetching…' : 'Call getUtxos()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/IsEnabledMethod.tsx
+++ b/vultisig-playground/src/components/cardano/IsEnabledMethod.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import type { CardanoCip30InitialApi, MethodComponentProps } from './types'
+import { formatCip30Error } from './cardanoUtils'
+
+export function IsEnabledMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    const api = provider as CardanoCip30InitialApi
+    setLoading(true)
+    try {
+      const result = await api.isEnabled()
+      onResult(result)
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Returns true if the dApp already has connection access (no user prompt).
+      </p>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Checking…' : 'Call isEnabled()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/SignDataMethod.tsx
+++ b/vultisig-playground/src/components/cardano/SignDataMethod.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import type { MethodComponentProps } from './types'
+import { formatCip30Error, getEnabledApi } from './cardanoUtils'
+import { fromHex, toHex } from './cbor'
+
+export function SignDataMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [addressHex, setAddressHex] = useState('')
+  const [payloadMode, setPayloadMode] = useState<'utf8' | 'hex'>('utf8')
+  const [payload, setPayload] = useState('')
+  const [loadingAddress, setLoadingAddress] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  const prefillAddress = async () => {
+    setLoadingAddress(true)
+    try {
+      const api = await getEnabledApi(provider)
+      const addr = await api.getChangeAddress()
+      setAddressHex(addr)
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoadingAddress(false)
+    }
+  }
+
+  const fillSample = () => {
+    setPayloadMode('utf8')
+    setPayload('Hello from Vultisig Playground')
+  }
+
+  const handleSign = async () => {
+    if (!addressHex.trim()) {
+      onError('Address (hex) is required. Click "Use connected address" to auto-fill.')
+      return
+    }
+    if (!payload.trim()) {
+      onError('Payload is required.')
+      return
+    }
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      const payloadHex =
+        payloadMode === 'hex'
+          ? payload.trim().replace(/^0x/i, '')
+          : toHex(new TextEncoder().encode(payload))
+
+      // Validate that hex inputs round-trip cleanly.
+      if (payloadMode === 'hex') fromHex(payloadHex)
+
+      const result = await api.signData(addressHex.trim(), payloadHex)
+      onResult({
+        signedAddressHex: addressHex.trim(),
+        payloadHex,
+        signature: result.signature,
+        key: result.key,
+        note: 'signature = COSE_Sign1 hex; key = COSE_Key hex',
+      })
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Signs a payload with CIP-30 signData (COSE_Sign1 over the connected account's spending key).
+      </p>
+
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <label className="block text-xs font-medium text-gray-700">
+            Address (hex) <span className="text-red-500">*</span>
+          </label>
+          <button
+            onClick={prefillAddress}
+            disabled={loadingAddress}
+            className="text-xs text-blue-600 hover:text-blue-800 disabled:text-gray-400"
+          >
+            {loadingAddress ? 'Loading…' : 'Use connected address'}
+          </button>
+        </div>
+        <input
+          type="text"
+          value={addressHex}
+          onChange={(e) => setAddressHex(e.target.value)}
+          placeholder="hex of raw address bytes (must match connected account)"
+          className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Payload Encoding</label>
+        <div className="flex gap-2">
+          {(['utf8', 'hex'] as const).map((m) => (
+            <button
+              key={m}
+              onClick={() => setPayloadMode(m)}
+              className={`px-3 py-1.5 text-xs rounded border transition-colors ${
+                payloadMode === m
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+              }`}
+            >
+              {m === 'utf8' ? 'UTF-8 text' : 'Hex bytes'}
+            </button>
+          ))}
+          <button
+            onClick={fillSample}
+            className="ml-auto px-2 py-1.5 text-xs bg-gray-100 border border-gray-300 text-gray-700 rounded hover:bg-gray-200 transition-colors"
+          >
+            Load sample
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">
+          Payload <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          value={payload}
+          onChange={(e) => setPayload(e.target.value)}
+          placeholder={payloadMode === 'utf8' ? 'Hello, Cardano!' : 'a1b2c3…'}
+          className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y"
+          rows={3}
+        />
+      </div>
+
+      <button
+        onClick={handleSign}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Signing…' : 'Call signData()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/SignTxMethod.tsx
+++ b/vultisig-playground/src/components/cardano/SignTxMethod.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react'
+import type { MethodComponentProps } from './types'
+import { formatCip30Error, formatLovelace, getEnabledApi } from './cardanoUtils'
+import { buildSampleUnsignedTx, buildSignedTx } from './sampleTxBuilder'
+
+export function SignTxMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [txHex, setTxHex] = useState('')
+  const [partialSign, setPartialSign] = useState(false)
+  const [bodyBytes, setBodyBytes] = useState<Uint8Array | null>(null)
+  const [witnessSetHex, setWitnessSetHex] = useState<string | null>(null)
+  const [signedTxHex, setSignedTxHex] = useState<string | null>(null)
+  const [sampleSummary, setSampleSummary] = useState<{
+    inputTxHash: string
+    inputIndex: number
+    outputAddressHex: string
+    outputLovelace: string
+    feeLovelace: string
+    ttl: number
+  } | null>(null)
+  const [buildingSample, setBuildingSample] = useState(false)
+  const [signing, setSigning] = useState(false)
+
+  const handleBuildSample = async () => {
+    setBuildingSample(true)
+    setWitnessSetHex(null)
+    setSignedTxHex(null)
+    try {
+      const api = await getEnabledApi(provider)
+      const built = await buildSampleUnsignedTx(api)
+      setTxHex(built.unsignedTxHex)
+      setBodyBytes(built.bodyBytes)
+      setSampleSummary({
+        inputTxHash: built.inputTxHash,
+        inputIndex: built.inputIndex,
+        outputAddressHex: built.outputAddressHex,
+        outputLovelace: built.outputLovelace,
+        feeLovelace: built.feeLovelace,
+        ttl: built.ttl,
+      })
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setBuildingSample(false)
+    }
+  }
+
+  const handleSign = async () => {
+    if (!txHex.trim()) {
+      onError('Transaction CBOR hex is required')
+      return
+    }
+    setSigning(true)
+    setWitnessSetHex(null)
+    setSignedTxHex(null)
+    try {
+      const api = await getEnabledApi(provider)
+      const witness = await api.signTx(txHex.trim(), partialSign)
+      setWitnessSetHex(witness)
+      const signed = bodyBytes ? buildSignedTx(bodyBytes, witness) : null
+      if (signed) setSignedTxHex(signed)
+      onResult({
+        witnessSetHex: witness,
+        signedTxHex: signed,
+        note: signed
+          ? 'Signed tx built from the sample body. Copy signedTxHex into the submitTx tab.'
+          : 'Witness set returned. The dApp must combine it with the tx body to produce a submittable CBOR.',
+      })
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setSigning(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Signs a Cardano transaction. The wallet hashes the tx body and returns a CBOR witness set.
+      </p>
+
+      <div className="bg-indigo-50 border border-indigo-200 rounded-md p-3 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-semibold text-indigo-900">Sample transaction builder</span>
+          <button
+            onClick={handleBuildSample}
+            disabled={buildingSample}
+            className="px-3 py-1.5 text-xs bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+          >
+            {buildingSample ? 'Building…' : 'Build sample tx'}
+          </button>
+        </div>
+        <p className="text-xs text-indigo-800">
+          Builds a 1-input / 1-output self-transfer using the largest lovelace-only UTXO. Fee: 0.2
+          ADA. TTL fetched from api.vultisig.com/cardano/tip.
+        </p>
+        {sampleSummary && (
+          <div className="text-xs font-mono text-indigo-900 bg-white rounded p-2 space-y-1 break-all">
+            <div>
+              <span className="font-semibold">input:</span> {sampleSummary.inputTxHash}#
+              {sampleSummary.inputIndex}
+            </div>
+            <div>
+              <span className="font-semibold">output:</span>{' '}
+              {formatLovelace(BigInt(sampleSummary.outputLovelace))} → {sampleSummary.outputAddressHex}
+            </div>
+            <div>
+              <span className="font-semibold">fee:</span>{' '}
+              {formatLovelace(BigInt(sampleSummary.feeLovelace))}
+            </div>
+            <div>
+              <span className="font-semibold">TTL slot:</span> {sampleSummary.ttl}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">
+          Transaction CBOR hex <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          value={txHex}
+          onChange={(e) => {
+            setTxHex(e.target.value)
+            setBodyBytes(null)
+            setSampleSummary(null)
+            setWitnessSetHex(null)
+            setSignedTxHex(null)
+          }}
+          placeholder="84a4...  (hex-encoded CBOR transaction)"
+          className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y"
+          rows={5}
+        />
+      </div>
+
+      <label className="flex items-center gap-2 text-xs text-gray-700">
+        <input
+          type="checkbox"
+          checked={partialSign}
+          onChange={(e) => setPartialSign(e.target.checked)}
+          className="rounded"
+        />
+        partialSign (do not error if wallet cannot sign all required witnesses)
+      </label>
+
+      <button
+        onClick={handleSign}
+        disabled={signing || !txHex.trim()}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {signing ? 'Signing…' : 'Call signTx()'}
+      </button>
+
+      {(witnessSetHex || signedTxHex) && (
+        <div className="border-t border-gray-200 pt-3 space-y-2 text-xs">
+          {witnessSetHex && (
+            <div className="break-all font-mono">
+              <span className="font-semibold text-gray-700">witness set hex:</span>
+              <div className="mt-1 p-2 bg-gray-50 rounded">{witnessSetHex}</div>
+            </div>
+          )}
+          {signedTxHex && (
+            <div className="break-all font-mono">
+              <span className="font-semibold text-gray-700">
+                signed tx hex (ready for submitTx):
+              </span>
+              <div className="mt-1 p-2 bg-green-50 border border-green-200 rounded">
+                {signedTxHex}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/SubmitTxMethod.tsx
+++ b/vultisig-playground/src/components/cardano/SubmitTxMethod.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import type { MethodComponentProps } from './types'
+import { formatCip30Error, getEnabledApi } from './cardanoUtils'
+
+export function SubmitTxMethod({ provider, onResult, onError }: MethodComponentProps) {
+  const [txHex, setTxHex] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async () => {
+    if (!txHex.trim()) {
+      onError('Signed transaction CBOR hex is required')
+      return
+    }
+    setLoading(true)
+    try {
+      const api = await getEnabledApi(provider)
+      const txHash = await api.submitTx(txHex.trim())
+      onResult({ txHash, explorer: `https://cardanoscan.io/transaction/${txHash}` })
+    } catch (err) {
+      onError(formatCip30Error(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Broadcasts a fully signed transaction CBOR to the Cardano network. Returns the tx hash.
+      </p>
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">
+          Signed transaction CBOR hex <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          value={txHex}
+          onChange={(e) => setTxHex(e.target.value)}
+          placeholder="Paste the signed tx hex produced by signTx (with body + witness set combined)"
+          className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y"
+          rows={5}
+        />
+      </div>
+      <button
+        onClick={handleSubmit}
+        disabled={loading || !txHex.trim()}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Submitting…' : 'Call submitTx()'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/cardano/cardanoUtils.ts
+++ b/vultisig-playground/src/components/cardano/cardanoUtils.ts
@@ -1,0 +1,182 @@
+import { decode as cborDecode } from 'cbor-x'
+import type { CardanoCip30ApiError, CardanoCip30FullApi, CardanoCip30InitialApi } from './types'
+import { fromHex } from './cbor'
+
+/**
+ * Calls provider.enable() to retrieve the CIP-30 full API.
+ * enable() is idempotent per CIP-30: after initial user approval it returns
+ * immediately without re-prompting.
+ */
+export async function getEnabledApi(provider: unknown): Promise<CardanoCip30FullApi> {
+  const initial = provider as CardanoCip30InitialApi | null
+  if (!initial || typeof initial.enable !== 'function') {
+    throw new Error('Cardano CIP-30 provider is not available')
+  }
+  return initial.enable()
+}
+
+/**
+ * Formats errors thrown by CIP-30 methods (typed `{code, info}`) into a string.
+ * Falls back to plain Error messages.
+ */
+export function formatCip30Error(err: unknown): string {
+  if (err && typeof err === 'object' && 'code' in err && 'info' in err) {
+    const e = err as CardanoCip30ApiError
+    const max = e.maxSize !== undefined ? ` (maxSize: ${e.maxSize})` : ''
+    return `[code ${e.code}] ${e.info}${max}`
+  }
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+/** Formats lovelace (bigint) as ADA with 6 decimal places. */
+export function formatLovelace(lovelace: bigint | number): string {
+  const v = typeof lovelace === 'bigint' ? lovelace : BigInt(lovelace)
+  const whole = v / 1_000_000n
+  const frac = v % 1_000_000n
+  return `${whole.toString()}.${frac.toString().padStart(6, '0')} ADA`
+}
+
+type MultiAsset = Map<Uint8Array, Map<Uint8Array, bigint | number>>
+
+type DecodedValue = bigint | number | [bigint | number, MultiAsset]
+
+interface DecodedAsset {
+  policyId: string
+  assetName: string
+  quantity: string
+}
+
+interface DecodedBalance {
+  lovelace: string
+  assets: DecodedAsset[]
+}
+
+function toHexLocal(bytes: Uint8Array): string {
+  let hex = ''
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
+/** Decodes a CBOR value (lovelace-only uint OR [lovelace, multiasset]). */
+export function decodeCardanoValue(bytes: Uint8Array): DecodedBalance {
+  const decoded = cborDecode(bytes) as DecodedValue
+  let lovelace: bigint
+  let multiAsset: MultiAsset | null = null
+
+  if (Array.isArray(decoded)) {
+    lovelace = BigInt(decoded[0])
+    multiAsset = decoded[1]
+  } else {
+    lovelace = BigInt(decoded)
+  }
+
+  const assets: DecodedAsset[] = []
+  if (multiAsset instanceof Map) {
+    for (const [policy, inner] of multiAsset.entries()) {
+      if (!(inner instanceof Map)) continue
+      for (const [name, qty] of inner.entries()) {
+        assets.push({
+          policyId: toHexLocal(policy),
+          assetName: toHexLocal(name),
+          quantity: BigInt(qty).toString(),
+        })
+      }
+    }
+  }
+
+  return { lovelace: lovelace.toString(), assets }
+}
+
+export interface DecodedUtxo {
+  txHash: string
+  outputIndex: number
+  address: string
+  value: DecodedBalance
+}
+
+/**
+ * Decodes a single CIP-30 UTXO (CBOR: `[[tx_hash, index], output]`).
+ * `output` can be either a legacy array `[address, value]` or a post-Babbage
+ * map with integer keys (0=address, 1=value).
+ */
+export function decodeCardanoUtxo(bytes: Uint8Array): DecodedUtxo {
+  const decoded = cborDecode(bytes) as [[Uint8Array, number | bigint], unknown]
+  const [[txHashBytes, indexRaw], output] = decoded
+
+  let addressBytes: Uint8Array
+  let valueDecoded: DecodedValue
+
+  if (Array.isArray(output)) {
+    addressBytes = output[0] as Uint8Array
+    valueDecoded = output[1] as DecodedValue
+  } else if (output instanceof Map) {
+    addressBytes = output.get(0) as Uint8Array
+    valueDecoded = output.get(1) as DecodedValue
+  } else {
+    throw new Error('Unsupported UTXO output format')
+  }
+
+  const balance = valueToBalance(valueDecoded)
+
+  return {
+    txHash: toHexLocal(txHashBytes),
+    outputIndex: Number(indexRaw),
+    address: toHexLocal(addressBytes),
+    value: balance,
+  }
+}
+
+function valueToBalance(decoded: DecodedValue): DecodedBalance {
+  let lovelace: bigint
+  let multiAsset: MultiAsset | null = null
+
+  if (Array.isArray(decoded)) {
+    lovelace = BigInt(decoded[0])
+    multiAsset = decoded[1]
+  } else {
+    lovelace = BigInt(decoded)
+  }
+
+  const assets: DecodedAsset[] = []
+  if (multiAsset instanceof Map) {
+    for (const [policy, inner] of multiAsset.entries()) {
+      if (!(inner instanceof Map)) continue
+      for (const [name, qty] of inner.entries()) {
+        assets.push({
+          policyId: toHexLocal(policy),
+          assetName: toHexLocal(name),
+          quantity: BigInt(qty).toString(),
+        })
+      }
+    }
+  }
+
+  return { lovelace: lovelace.toString(), assets }
+}
+
+/** Returns lovelace value of the largest lovelace-only UTXO, or null. */
+export function pickLargestLovelaceUtxo(utxoHexes: string[]): {
+  utxoHex: string
+  decoded: DecodedUtxo
+  lovelace: bigint
+} | null {
+  let best: { utxoHex: string; decoded: DecodedUtxo; lovelace: bigint } | null = null
+  for (const hex of utxoHexes) {
+    const decoded = decodeCardanoUtxo(fromHex(hex))
+    if (decoded.value.assets.length > 0) continue
+    const lovelace = BigInt(decoded.value.lovelace)
+    if (!best || lovelace > best.lovelace) {
+      best = { utxoHex: hex, decoded, lovelace }
+    }
+  }
+  return best
+}
+
+/** Previews a hex string for display — shows first/last chars with length. */
+export function hexPreview(hex: string, chars = 12): string {
+  if (hex.length <= chars * 2 + 5) return hex
+  return `${hex.slice(0, chars)}…${hex.slice(-chars)} (${hex.length / 2} bytes)`
+}

--- a/vultisig-playground/src/components/cardano/cbor.ts
+++ b/vultisig-playground/src/components/cardano/cbor.ts
@@ -1,0 +1,124 @@
+/**
+ * Minimal canonical-CBOR encoder for building Cardano transactions.
+ *
+ * Cardano expects deterministic CBOR for tx bodies so that the body hash is
+ * stable. We hand-roll the primitives here (rather than relying on cbor-x)
+ * because cbor-x does not guarantee canonical map ordering or length forms.
+ *
+ * cbor-x is used on the decode side only, where canonical form doesn't matter.
+ */
+
+const concat = (parts: Uint8Array[]): Uint8Array => {
+  let total = 0
+  for (const p of parts) total += p.length
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const p of parts) {
+    out.set(p, offset)
+    offset += p.length
+  }
+  return out
+}
+
+/**
+ * Encodes a CBOR head byte for a given major type and unsigned argument,
+ * using the shortest valid length form.
+ */
+const encodeHead = (majorType: number, argument: bigint): Uint8Array => {
+  const mt = majorType << 5
+  if (argument < 0n) {
+    throw new Error(`CBOR head argument must be non-negative: ${argument}`)
+  }
+  if (argument < 24n) {
+    return new Uint8Array([mt | Number(argument)])
+  }
+  if (argument < 0x100n) {
+    return new Uint8Array([mt | 24, Number(argument)])
+  }
+  if (argument < 0x10000n) {
+    const n = Number(argument)
+    return new Uint8Array([mt | 25, (n >> 8) & 0xff, n & 0xff])
+  }
+  if (argument < 0x100000000n) {
+    const n = Number(argument)
+    return new Uint8Array([
+      mt | 26,
+      (n >>> 24) & 0xff,
+      (n >>> 16) & 0xff,
+      (n >>> 8) & 0xff,
+      n & 0xff,
+    ])
+  }
+  const buf = new Uint8Array(9)
+  buf[0] = mt | 27
+  const view = new DataView(buf.buffer)
+  view.setBigUint64(1, argument, false)
+  return buf
+}
+
+export const cborUint = (value: bigint | number): Uint8Array => {
+  const v = typeof value === 'bigint' ? value : BigInt(value)
+  if (v < 0n) throw new Error(`cborUint: negative value ${v}`)
+  return encodeHead(0, v)
+}
+
+export const cborNegInt = (value: bigint | number): Uint8Array => {
+  const v = typeof value === 'bigint' ? value : BigInt(value)
+  if (v >= 0n) throw new Error(`cborNegInt: non-negative value ${v}`)
+  return encodeHead(1, -1n - v)
+}
+
+export const cborInt = (value: bigint | number): Uint8Array => {
+  const v = typeof value === 'bigint' ? value : BigInt(value)
+  return v < 0n ? cborNegInt(v) : cborUint(v)
+}
+
+export const cborBytes = (bytes: Uint8Array): Uint8Array =>
+  concat([encodeHead(2, BigInt(bytes.length)), bytes])
+
+export const cborText = (s: string): Uint8Array => {
+  const bytes = new TextEncoder().encode(s)
+  return concat([encodeHead(3, BigInt(bytes.length)), bytes])
+}
+
+export const cborArray = (items: Uint8Array[]): Uint8Array =>
+  concat([encodeHead(4, BigInt(items.length)), ...items])
+
+export const cborMap = (
+  entries: Array<[Uint8Array, Uint8Array]>
+): Uint8Array => {
+  const parts: Uint8Array[] = [encodeHead(5, BigInt(entries.length))]
+  for (const [k, v] of entries) {
+    parts.push(k, v)
+  }
+  return concat(parts)
+}
+
+export const cborBool = (b: boolean): Uint8Array =>
+  new Uint8Array([b ? 0xf5 : 0xf4])
+
+export const cborNull = (): Uint8Array => new Uint8Array([0xf6])
+
+export const toHex = (bytes: Uint8Array): string => {
+  let hex = ''
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
+export const fromHex = (hex: string): Uint8Array => {
+  const clean = hex.replace(/^0x/i, '').trim()
+  if (clean.length % 2 !== 0) {
+    throw new Error('fromHex: odd-length hex string')
+  }
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    const byte = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+    if (Number.isNaN(byte)) {
+      throw new Error(`fromHex: invalid hex byte at ${i * 2}`)
+    }
+    out[i] = byte
+  }
+  return out
+}

--- a/vultisig-playground/src/components/cardano/methodMapping.tsx
+++ b/vultisig-playground/src/components/cardano/methodMapping.tsx
@@ -1,0 +1,37 @@
+import type { ReactElement } from 'react'
+import type { MethodComponentProps } from './types'
+import { IsEnabledMethod } from './IsEnabledMethod'
+import { EnableMethod } from './EnableMethod'
+import { GetNetworkIdMethod } from './GetNetworkIdMethod'
+import { GetExtensionsMethod } from './GetExtensionsMethod'
+import { GetUsedAddressesMethod } from './GetUsedAddressesMethod'
+import { GetUnusedAddressesMethod } from './GetUnusedAddressesMethod'
+import { GetChangeAddressMethod } from './GetChangeAddressMethod'
+import { GetRewardAddressesMethod } from './GetRewardAddressesMethod'
+import { GetBalanceMethod } from './GetBalanceMethod'
+import { GetUtxosMethod } from './GetUtxosMethod'
+import { SignDataMethod } from './SignDataMethod'
+import { SignTxMethod } from './SignTxMethod'
+import { SubmitTxMethod } from './SubmitTxMethod'
+
+type MethodComponent = (props: MethodComponentProps) => ReactElement
+
+export const cardanoMethodMapping: Record<string, MethodComponent> = {
+  isEnabled: IsEnabledMethod,
+  enable: EnableMethod,
+  getNetworkId: GetNetworkIdMethod,
+  getExtensions: GetExtensionsMethod,
+  getUsedAddresses: GetUsedAddressesMethod,
+  getUnusedAddresses: GetUnusedAddressesMethod,
+  getChangeAddress: GetChangeAddressMethod,
+  getRewardAddresses: GetRewardAddressesMethod,
+  getBalance: GetBalanceMethod,
+  getUtxos: GetUtxosMethod,
+  signData: SignDataMethod,
+  signTx: SignTxMethod,
+  submitTx: SubmitTxMethod,
+}
+
+export function getMethodComponent(methodName: string): MethodComponent | null {
+  return cardanoMethodMapping[methodName] || null
+}

--- a/vultisig-playground/src/components/cardano/sampleTxBuilder.ts
+++ b/vultisig-playground/src/components/cardano/sampleTxBuilder.ts
@@ -1,0 +1,126 @@
+import {
+  cborArray,
+  cborBool,
+  cborBytes,
+  cborMap,
+  cborNull,
+  cborUint,
+  fromHex,
+  toHex,
+} from './cbor'
+import { pickLargestLovelaceUtxo } from './cardanoUtils'
+import type { CardanoCip30FullApi } from './types'
+
+const SAMPLE_FEE_LOVELACE = 200_000n // 0.2 ADA — safe overpay for a 1-in/1-out tx
+const TTL_SLOT_BUFFER = 7_200 // ~2 hours on mainnet
+
+const VULTISIG_CARDANO_TIP_URL = 'https://api.vultisig.com/cardano/tip'
+
+async function fetchCurrentSlot(): Promise<number> {
+  const response = await fetch(VULTISIG_CARDANO_TIP_URL, {
+    headers: { accept: 'application/json' },
+  })
+  if (!response.ok) {
+    throw new Error(
+      `Vultisig cardano tip fetch failed: ${response.status} ${response.statusText}`
+    )
+  }
+  const body = (await response.json()) as Array<{ abs_slot: number }>
+  if (!Array.isArray(body) || body.length === 0 || typeof body[0].abs_slot !== 'number') {
+    throw new Error('Vultisig cardano tip returned unexpected shape')
+  }
+  return body[0].abs_slot
+}
+
+export interface BuiltSampleTx {
+  /** Full unsigned transaction CBOR (hex). This is what gets passed to signTx. */
+  unsignedTxHex: string
+  /** Raw body bytes — needed to rebuild the final signed tx after signing. */
+  bodyBytes: Uint8Array
+  inputTxHash: string
+  inputIndex: number
+  outputAddressHex: string
+  outputLovelace: string
+  feeLovelace: string
+  ttl: number
+}
+
+/**
+ * Builds a minimal self-transfer Cardano transaction using the connected
+ * wallet's UTXOs and change address:
+ *
+ *   inputs:  largest lovelace-only UTXO
+ *   outputs: [change_address → (utxo.amount - fee)]
+ *   fee:     0.2 ADA (safe overpay)
+ *   TTL:     current_slot + 7200
+ *
+ * The user can then sign this via signTx and combine with buildSignedTx().
+ */
+export async function buildSampleUnsignedTx(
+  api: CardanoCip30FullApi
+): Promise<BuiltSampleTx> {
+  const [changeAddressHex, utxoHexes] = await Promise.all([
+    api.getChangeAddress(),
+    api.getUtxos(),
+  ])
+
+  if (!utxoHexes || utxoHexes.length === 0) {
+    throw new Error('No UTXOs available. Fund the wallet first.')
+  }
+
+  const selected = pickLargestLovelaceUtxo(utxoHexes)
+  if (!selected) {
+    throw new Error('No lovelace-only UTXOs found (all UTXOs contain native assets).')
+  }
+
+  if (selected.lovelace <= SAMPLE_FEE_LOVELACE) {
+    throw new Error(
+      `Largest UTXO (${selected.lovelace} lovelace) is too small to cover the ${SAMPLE_FEE_LOVELACE} lovelace sample fee.`
+    )
+  }
+
+  const outputLovelace = selected.lovelace - SAMPLE_FEE_LOVELACE
+  const ttl = (await fetchCurrentSlot()) + TTL_SLOT_BUFFER
+
+  const inputs = cborArray([
+    cborArray([
+      cborBytes(fromHex(selected.decoded.txHash)),
+      cborUint(selected.decoded.outputIndex),
+    ]),
+  ])
+
+  const outputs = cborArray([
+    cborArray([cborBytes(fromHex(changeAddressHex)), cborUint(outputLovelace)]),
+  ])
+
+  const bodyBytes = cborMap([
+    [cborUint(0), inputs],
+    [cborUint(1), outputs],
+    [cborUint(2), cborUint(SAMPLE_FEE_LOVELACE)],
+    [cborUint(3), cborUint(ttl)],
+  ])
+
+  const emptyWitnessSet = cborMap([])
+  const txBytes = cborArray([bodyBytes, emptyWitnessSet, cborBool(true), cborNull()])
+
+  return {
+    unsignedTxHex: toHex(txBytes),
+    bodyBytes,
+    inputTxHash: selected.decoded.txHash,
+    inputIndex: selected.decoded.outputIndex,
+    outputAddressHex: changeAddressHex,
+    outputLovelace: outputLovelace.toString(),
+    feeLovelace: SAMPLE_FEE_LOVELACE.toString(),
+    ttl,
+  }
+}
+
+/**
+ * Combines a body (cached from buildSampleUnsignedTx) with the witness set
+ * returned by signTx to produce a fully signed transaction CBOR.
+ */
+export function buildSignedTx(bodyBytes: Uint8Array, witnessSetHex: string): string {
+  const witnessSet = fromHex(witnessSetHex)
+  const tx = cborArray([bodyBytes, witnessSet, cborBool(true), cborNull()])
+  return toHex(tx)
+}

--- a/vultisig-playground/src/components/cardano/types.ts
+++ b/vultisig-playground/src/components/cardano/types.ts
@@ -1,0 +1,26 @@
+import type {
+  CardanoCip30Extension,
+  CardanoCip30FullApi,
+  CardanoCip30InitialApi,
+  CardanoPaginate,
+} from '../../types/vultisig'
+
+export type {
+  CardanoCip30Extension,
+  CardanoCip30FullApi,
+  CardanoCip30InitialApi,
+  CardanoPaginate,
+}
+
+export interface CardanoCip30ApiError {
+  code: number
+  info: string
+  maxSize?: number
+}
+
+export interface MethodComponentProps {
+  provider: unknown
+  onResult: (result: unknown) => void
+  onError: (error: string) => void
+  onAccountUpdate?: (accounts: string[]) => void
+}

--- a/vultisig-playground/src/components/methodMapping.ts
+++ b/vultisig-playground/src/components/methodMapping.ts
@@ -13,6 +13,7 @@ import { getMethodComponent as getSolanaMethodComponent } from './solana/methodM
 import { getMethodComponent as getPolkadotMethodComponent } from './polkadot/methodMapping'
 import { getMethodComponent as getDashMethodComponent } from './dash/methodMapping'
 import { getMethodComponent as getTonMethodComponent } from './ton/methodMapping'
+import { getMethodComponent as getCardanoMethodComponent } from './cardano/methodMapping'
 import type { ReactElement } from 'react'
 
 interface MethodComponentProps {
@@ -65,6 +66,9 @@ export function getMethodComponent(chainName: string, providerName: string, meth
       return getDashMethodComponent(methodName)
     case 'ton':
       return getTonMethodComponent(methodName)
+    case 'cardano':
+    case 'ada':
+      return getCardanoMethodComponent(methodName)
     default:
       return null
   }

--- a/vultisig-playground/src/config/chainProviders.ts
+++ b/vultisig-playground/src/config/chainProviders.ts
@@ -14,6 +14,7 @@ export const chainProviders: Record<string, string[]> = {
   dot: ['polkadot'],
   dash: ['dash'],
   ton: ['ton'],
+  ada: ['cardano'],
 }
 
 export function getChainProviders(chainName: string): string[] {

--- a/vultisig-playground/src/config/providerNames.ts
+++ b/vultisig-playground/src/config/providerNames.ts
@@ -15,6 +15,7 @@ export const providerDisplayNames: Record<string, string> = {
   polkadot: 'injectedWeb3',
   dash: 'Native',
   ton: 'TonConnect',
+  cardano: 'CIP-30',
 }
 
 export function getProviderDisplayName(providerName: string): string {

--- a/vultisig-playground/src/hooks/useProviderMethods.ts
+++ b/vultisig-playground/src/hooks/useProviderMethods.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { tronMethodMapping } from '../components/tron/methodMapping'
 import { tonMethodMapping } from '../components/ton/methodMapping'
+import { cardanoMethodMapping } from '../components/cardano/methodMapping'
 
 export function useProviderMethods(providerName: string) {
   const [methods, setMethods] = useState<string[]>([])
@@ -19,6 +20,15 @@ export function useProviderMethods(providerName: string) {
       const tonProvider = window.vultisig?.ton as { tonconnect?: unknown } | undefined
       if (tonProvider?.tonconnect) {
         setMethods(Object.keys(tonMethodMapping))
+      } else {
+        setMethods([])
+      }
+      return
+    }
+
+    if (providerName === 'cardano') {
+      if (window.cardano?.vultisig) {
+        setMethods(Object.keys(cardanoMethodMapping))
       } else {
         setMethods([])
       }

--- a/vultisig-playground/src/pages/ProviderPlayground.tsx
+++ b/vultisig-playground/src/pages/ProviderPlayground.tsx
@@ -25,6 +25,9 @@ function ProviderPlayground() {
     if (provider === 'polkadot') {
       return window.injectedWeb3?.['polkadot-js'] || null
     }
+    if (provider === 'cardano') {
+      return window.cardano?.vultisig || null
+    }
     if (!window.vultisig) return null
     if (provider === 'ton') {
       const tonProvider = window.vultisig.ton as { tonconnect?: unknown } | undefined
@@ -42,6 +45,12 @@ function ProviderPlayground() {
         setError("window.injectedWeb3 detected, but the 'polkadot-js' provider is not available.")
       } else {
         setError('window.injectedWeb3 not detected. Please install the Vultisig extension.')
+      }
+    } else if (provider === 'cardano') {
+      if (window.cardano) {
+        setError("window.cardano detected, but the 'vultisig' CIP-30 provider is not available.")
+      } else {
+        setError('window.cardano not detected. Please install the Vultisig extension.')
       }
     } else if (window.vultisig) {
       setError(`Vultisig extension detected, but ${provider} provider is not available.`)

--- a/vultisig-playground/src/types/vultisig.d.ts
+++ b/vultisig-playground/src/types/vultisig.d.ts
@@ -36,6 +36,39 @@ interface VultisigWindow {
     ton?: { tonconnect: unknown }
     [key: string]: unknown
   }
+  cardano?: Record<string, CardanoCip30InitialApi | undefined>
+}
+
+export interface CardanoCip30Extension {
+  cip: number
+}
+
+export interface CardanoPaginate {
+  page: number
+  limit: number
+}
+
+export interface CardanoCip30FullApi {
+  getExtensions: () => Promise<CardanoCip30Extension[]>
+  getNetworkId: () => Promise<number>
+  getUsedAddresses: (paginate?: CardanoPaginate) => Promise<string[]>
+  getUnusedAddresses: () => Promise<string[]>
+  getChangeAddress: () => Promise<string>
+  getRewardAddresses: () => Promise<string[]>
+  getBalance: () => Promise<string>
+  getUtxos: (amount?: string, paginate?: CardanoPaginate) => Promise<string[] | null>
+  signTx: (tx: string, partialSign?: boolean) => Promise<string>
+  signData: (addr: string, payload: string) => Promise<{ signature: string; key: string }>
+  submitTx: (tx: string) => Promise<string>
+}
+
+export interface CardanoCip30InitialApi {
+  name: string
+  icon: string
+  apiVersion: string
+  supportedExtensions: CardanoCip30Extension[]
+  isEnabled: () => Promise<boolean>
+  enable: () => Promise<CardanoCip30FullApi>
 }
 
 export interface PolkadotInjectedAccount {


### PR DESCRIPTION
## Summary
- New **Cardano** entry in the playground sidebar that drives the CIP-30 dApp-Wallet Web Bridge exposed by the Vultisig extension at `window.cardano.vultisig`.
- 13 CIP-30 method tabs (isEnabled, enable, getNetworkId, getExtensions, used/unused/change/reward addresses, getBalance, getUtxos, signData, signTx, submitTx), with `cbor-x` decoding balance/UTXO CBOR for readable output.
- `signTx` ships with an end-to-end **sample tx builder**: picks the largest lovelace-only UTXO, fetches the current slot from `api.vultisig.com/cardano/tip`, assembles a 1-in/1-out self-transfer with a flat 0.2 ADA fee, signs via the wallet, and reconstructs the fully signed CBOR for copy-paste into `submitTx`.

## Notes
- Provider lookup is special-cased alongside `polkadot` and `ton` because CIP-30 lives on `window.cardano`, not under `window.vultisig.*`.
- Tx body CBOR is emitted through a small canonical encoder (not `cbor-x`) to keep the body hash deterministic; `cbor-x` is used only on the decode side where canonical form doesn't matter.
- Sample tx uses a flat overpay fee rather than protocol-params-based calculation — fine for demoing the signing/submit flow, wasteful for production.

## Test plan
- [ ] `npm run build` is clean
- [ ] With the Vultisig extension installed, open `/ada/cardano`; sidebar icon + all 13 tabs render
- [ ] `enable` triggers approval popup the first time, returns immediately after
- [ ] `getBalance` and `getUtxos` show decoded lovelace/assets alongside raw hex
- [ ] `signData` signs a UTF-8 payload against the prefilled change address and returns a COSE_Sign1 + COSE_Key pair
- [ ] `signTx` → **Build sample tx** produces a summary panel + unsigned CBOR hex
- [ ] `signTx` → **Call signTx()** returns a witness set and the UI reassembles a green "signed tx hex" block
- [ ] Pasting that hex into the `submitTx` tab broadcasts and returns a tx hash + Cardanoscan link