### PR TITLE
fix(playground): use Vultisig Solana RPC instead of disabled Alchemy endpoint

### DIFF
--- a/vultisig-playground/src/components/solana/solanaExamples.ts
+++ b/vultisig-playground/src/components/solana/solanaExamples.ts
@@ -21,7 +21,7 @@ import { PublicKey, Keypair, VersionedTransaction } from '@solana/web3.js'
 import { getTransactionEncoder } from '@solana/transactions'
 import { Buffer } from 'buffer'
 
-const SOLANA_RPC_URL = 'https://solana-mainnet.g.alchemy.com/v2/PiMBPAB_R6x92QTdZwt8H6tBvFIGV5SW'
+const SOLANA_RPC_URL = import.meta.env.VITE_SOLANA_RPC_URL || 'https://api.vultisig.com/solana/'
 
 type Blockhash = Awaited<ReturnType<ReturnType<ReturnType<typeof createSolanaRpc>['getLatestBlockhash']>['send']>>['value']
 

--- a/vultisig-playground/src/vite-env.d.ts
+++ b/vultisig-playground/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SOLANA_RPC_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
Fixes #36

## Summary

- Replace the hard-coded Alchemy Solana mainnet URL (which returns 403 — Solana Mainnet is not enabled on that Alchemy app) with the Vultisig-hosted RPC.
- Read the URL from `VITE_SOLANA_RPC_URL` with `https://api.vultisig.com/solana/` as the default, so future swaps don't require a code change.
- Add `src/vite-env.d.ts` to declare `import.meta.env` types (the project had none, so `tsc` errored on the new lookup).

## Repro of the bug (before)

```bash
$ curl -i 'https://solana-mainnet.g.alchemy.com/v2/PiMBPAB_R6x92QTdZwt8H6tBvFIGV5SW' \
    -H 'content-type: application/json' \
    --data-raw '{"id":"1","jsonrpc":"2.0","method":"getLatestBlockhash","params":[{"commitment":"confirmed"}]}'
HTTP/2 403
SOLANA_MAINNET is not enabled for this app. Visit this page to enable the network: https://dashboard.alchemy.com/apps/.../networks
```

User-visible: picking the **SOL Transfer (Legacy) – Transfer 0.01 SOL** template in `signAndSendTransaction` throws Solana error `#8100002` — the 403 bubbles up from the `getLatestBlockhash` call in the template builder.

## Proof of the replacement (after)

```bash
$ curl -s 'https://api.vultisig.com/solana/' \
    -H 'content-type: application/json' \
    --data-raw '{"id":"1","jsonrpc":"2.0","method":"getLatestBlockhash","params":[{"commitment":"confirmed"}]}'
{"jsonrpc":"2.0","result":{"context":{"apiVersion":"3.1.13","slot":419649442},"value":{"blockhash":"5rRxBWT9Rge3tgCmVnFf5YH93PEhTo7joZetAoJXFcK7","lastValidBlockHeight":397740362}},"id":"1"}
```

Same JSON-RPC shape as Alchemy, no auth.

## Security note

The committed Alchemy API key `PiMBPAB_R6x92QTdZwt8H6tBvFIGV5SW` has been in public git history since commit `aaa9c21`. Even with this swap, it should be treated as **leaked/compromised and rotated (or disabled) on Alchemy** — anyone who has cloned the repo has it. Rewriting public main history is out of scope for this PR.

## Test plan

- [ ] Open the deployed playground, pick **SOL Transfer (Legacy) – Transfer 0.01 SOL** in `signAndSendTransaction`, confirm the template builds without `#8100002`.
- [ ] Verify the other Solana templates (`transferSOL`, `transferUSDC`, `transferUSDCLegacy`, `partiallySignedSOL`) still construct successfully.
- [ ] Optionally test the env-var override by setting `VITE_SOLANA_RPC_URL` in a local `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)