### PR TITLE
feat(playground): XRPL/Ripple dApp panel + adversarial QA examples

### DIFF
--- a/vultisig-playground/src/components/ripple/GetAddressMethod.tsx
+++ b/vultisig-playground/src/components/ripple/GetAddressMethod.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import type { RippleProvider } from './types'
+
+interface GetAddressMethodProps {
+  provider: unknown
+  onResult: (result: unknown) => void
+  onError: (error: string) => void
+  onAccountUpdate?: (accounts: string[]) => void
+}
+
+export function GetAddressMethod({ provider, onResult, onError }: GetAddressMethodProps) {
+  const [loading, setLoading] = useState<boolean>(false)
+  const [includePublicKey, setIncludePublicKey] = useState<boolean>(false)
+
+  const handleGetAddress = async (): Promise<void> => {
+    const xrpl = provider as Partial<RippleProvider> | null
+
+    if (!xrpl?.getAddress || typeof xrpl.getAddress !== 'function') {
+      onError('XRPL provider or getAddress method not available')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const address = await xrpl.getAddress()
+      if (includePublicKey) {
+        if (!xrpl.getPublicKey || typeof xrpl.getPublicKey !== 'function') {
+          onError('getPublicKey method not available')
+          return
+        }
+        const publicKey = await xrpl.getPublicKey()
+        onResult({ ...address, ...publicKey })
+      } else {
+        onResult(address)
+      }
+    } catch (err) {
+      onError((err as Error).message || 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-gray-600">
+        Returns the connected XRPL address via <code className="bg-gray-100 px-1 rounded">getAddress</code>.
+        Optionally also fetches the public key via <code className="bg-gray-100 px-1 rounded">getPublicKey</code>.
+      </p>
+      <label className="flex items-center gap-2 text-xs text-gray-700">
+        <input
+          type="checkbox"
+          checked={includePublicKey}
+          onChange={(e) => setIncludePublicKey(e.target.checked)}
+          className="rounded border-gray-300 focus:ring-2 focus:ring-blue-500"
+        />
+        Also fetch public key
+      </label>
+      <button
+        onClick={handleGetAddress}
+        disabled={loading}
+        className="w-full px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? 'Fetching...' : 'Get address'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/ripple/SignTransactionMethod.tsx
+++ b/vultisig-playground/src/components/ripple/SignTransactionMethod.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react'
+import type { RippleProvider } from './types'
+import { getRippleExample, rippleExamples } from './rippleExamples'
+
+interface SignTransactionMethodProps {
+  provider: unknown
+  onResult: (result: unknown) => void
+  onError: (error: string) => void
+  onAccountUpdate?: (accounts: string[]) => void
+}
+
+type SignMode = 'sign' | 'submit'
+
+const legitExamples = rippleExamples.filter((e) => e.category === 'legit')
+const adversarialExamples = rippleExamples.filter((e) => e.category === 'adversarial')
+
+export function SignTransactionMethod({ provider, onResult, onError }: SignTransactionMethodProps) {
+  const [transactionJson, setTransactionJson] = useState<string>('')
+  const [selectedExampleId, setSelectedExampleId] = useState<string>('')
+  const [mode, setMode] = useState<SignMode>('sign')
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const selectedExample = getRippleExample(selectedExampleId)
+
+  const getProvider = (): RippleProvider | null => {
+    const xrpl = provider as Partial<RippleProvider> | null
+    if (!xrpl?.getAddress || !xrpl.signTransaction || !xrpl.submitTransaction) return null
+    return xrpl as RippleProvider
+  }
+
+  const handleSelectExample = async (id: string): Promise<void> => {
+    setSelectedExampleId(id)
+    if (!id) return
+
+    const example = getRippleExample(id)
+    if (!example) return
+
+    const xrpl = getProvider()
+    if (!xrpl) {
+      onError('XRPL provider not available')
+      return
+    }
+
+    try {
+      const { address } = await xrpl.getAddress()
+      const tx = example.build(address)
+      setTransactionJson(JSON.stringify(tx, null, 2))
+    } catch (err) {
+      onError((err as Error).message || 'Failed to build example')
+    }
+  }
+
+  const handleSign = async (): Promise<void> => {
+    if (!transactionJson.trim()) {
+      onError('Transaction JSON is required. Select an example or paste raw XRPL JSON.')
+      return
+    }
+
+    const xrpl = getProvider()
+    if (!xrpl) {
+      onError('XRPL provider or signing methods not available')
+      return
+    }
+
+    let transaction: Record<string, unknown>
+    try {
+      transaction = JSON.parse(transactionJson) as Record<string, unknown>
+    } catch (err) {
+      onError(`Invalid JSON: ${(err as Error).message}`)
+      return
+    }
+
+    setLoading(true)
+    try {
+      const result =
+        mode === 'submit'
+          ? await xrpl.submitTransaction({ transaction })
+          : await xrpl.signTransaction({ transaction })
+      onResult(result)
+    } catch (err) {
+      onError((err as Error).message || 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const submitMode = mode === 'submit'
+  const buttonColor = submitMode
+    ? 'bg-red-600 hover:bg-red-700'
+    : 'bg-blue-600 hover:bg-blue-700'
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-gray-600">
+        Signs raw XRPL JSON. <span className="font-medium">Sign only</span> returns the signed tx_blob without
+        broadcasting; <span className="font-medium">Sign &amp; submit</span> broadcasts to the network.
+      </p>
+
+      <div>
+        <label htmlFor="ripple-tx-example" className="block text-xs font-medium text-gray-700 mb-1">
+          Transaction example
+        </label>
+        <select
+          id="ripple-tx-example"
+          value={selectedExampleId}
+          onChange={(e) => handleSelectExample(e.target.value)}
+          className="w-full text-xs px-2 py-2 border border-gray-300 rounded bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="">Select example...</option>
+          <optgroup label="Legit">
+            {legitExamples.map((example) => (
+              <option key={example.id} value={example.id}>
+                {example.label}
+              </option>
+            ))}
+          </optgroup>
+          <optgroup label="Adversarial">
+            {adversarialExamples.map((example) => (
+              <option key={example.id} value={example.id}>
+                {example.label}
+              </option>
+            ))}
+          </optgroup>
+        </select>
+        {selectedExample && (
+          <p className="text-xs text-gray-500 mt-1">{selectedExample.description}</p>
+        )}
+      </div>
+
+      {selectedExample?.category === 'adversarial' && selectedExample.expectedWalletBehavior && (
+        <div className="p-3 bg-amber-50 border border-amber-300 rounded text-xs">
+          <p className="font-semibold text-amber-800">Expected wallet behavior</p>
+          <p className="text-amber-700 mt-1">{selectedExample.expectedWalletBehavior}</p>
+          <p className="text-amber-600 mt-2">
+            Compare this against what the wallet actually shows/does when you sign.
+          </p>
+        </div>
+      )}
+
+      <div>
+        <label htmlFor="ripple-tx-json" className="block text-xs font-medium text-gray-700 mb-1">
+          Transaction (raw XRPL JSON) <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          id="ripple-tx-json"
+          aria-required="true"
+          value={transactionJson}
+          onChange={(e) => setTransactionJson(e.target.value)}
+          placeholder="Select an example or paste raw XRPL JSON"
+          className="w-full px-3 py-2 text-xs font-mono border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y min-h-[160px]"
+          rows={10}
+        />
+        <p className="text-xs text-gray-500 mt-1">
+          Account is filled from the connected address when you load an example. Editable — tweak fields freely.
+        </p>
+      </div>
+
+      <fieldset className="flex gap-4 text-xs text-gray-700">
+        <legend className="sr-only">Signing mode</legend>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="ripple-sign-mode"
+            checked={mode === 'sign'}
+            onChange={() => setMode('sign')}
+            className="focus:ring-2 focus:ring-blue-500"
+          />
+          Sign only (no broadcast)
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="ripple-sign-mode"
+            checked={submitMode}
+            onChange={() => setMode('submit')}
+            className="focus:ring-2 focus:ring-blue-500"
+          />
+          Sign &amp; submit (broadcasts)
+        </label>
+      </fieldset>
+
+      <button
+        onClick={handleSign}
+        disabled={loading || !transactionJson.trim()}
+        className={`w-full px-4 py-2 text-sm text-white rounded disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors ${buttonColor}`}
+      >
+        {loading
+          ? submitMode ? 'Submitting...' : 'Signing...'
+          : submitMode ? 'Sign & submit' : 'Sign only'}
+      </button>
+    </div>
+  )
+}

--- a/vultisig-playground/src/components/ripple/methodMapping.tsx
+++ b/vultisig-playground/src/components/ripple/methodMapping.tsx
@@ -1,3 +1,5 @@
+import { GetAddressMethod } from './GetAddressMethod'
+import { SignTransactionMethod } from './SignTransactionMethod'
 import type { ReactElement } from 'react'
 
 interface MethodComponentProps {
@@ -9,9 +11,11 @@ interface MethodComponentProps {
 
 type MethodComponent = (props: MethodComponentProps) => ReactElement
 
-export const rippleMethodMapping: Record<string, MethodComponent> = {}
+export const rippleMethodMapping: Record<string, MethodComponent> = {
+  getAddress: GetAddressMethod,
+  signTransaction: SignTransactionMethod,
+}
 
 export function getMethodComponent(methodName: string): MethodComponent | null {
   return rippleMethodMapping[methodName] || null
 }
-

--- a/vultisig-playground/src/components/ripple/rippleExamples.ts
+++ b/vultisig-playground/src/components/ripple/rippleExamples.ts
@@ -1,0 +1,99 @@
+import {
+  buildOfferCreate,
+  buildPayment,
+  buildSelfSwapPayment,
+  buildTrustSet,
+  xrpToDrops,
+} from './rippleTransactions'
+
+// Adversarial cases reproduce the keysign-integrity XRPL gaps documented in
+// keysign-integrity chain-fields.md (issues windows#4595 / ios#5081 / android#5555):
+// fields that change what actually settles but may not surface in the wallet UI.
+// Every builder targets the connected account (self) — never a hardcoded third party —
+// so a "Sign & submit" misclick can't drain funds to an address the dev doesn't control.
+
+// tfPartialPayment: Amount becomes a ceiling, not a guaranteed delivery.
+const TF_PARTIAL_PAYMENT = 131072
+
+// Bitstamp USD appears only as a currency ISSUER (never a fund destination).
+const BITSTAMP_USD_ISSUER = 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
+
+export type RippleExampleCategory = 'legit' | 'adversarial'
+
+export interface RippleExample {
+  id: string
+  label: string
+  description: string
+  category: RippleExampleCategory
+  expectedWalletBehavior?: string
+  build: (account: string) => object
+}
+
+export const rippleExamples: RippleExample[] = [
+  {
+    id: 'nativePayment',
+    label: 'Native XRP payment',
+    description: 'Send 1 XRP to yourself; edit Destination to a real address to actually send elsewhere.',
+    category: 'legit',
+    build: (account) => buildPayment({ account, destination: account, xrp: '1' }),
+  },
+  {
+    id: 'selfSwap',
+    label: 'Self cross-currency payment',
+    description: 'Cross-currency-style Payment delivering 1 XRP to yourself with a 1.5 XRP SendMax cap.',
+    category: 'legit',
+    build: (account) => buildSelfSwapPayment({ account, deliverXrp: '1', sendMaxXrp: '1.5' }),
+  },
+  {
+    id: 'offerCreate',
+    label: 'OfferCreate (DEX)',
+    description: 'Offer to buy 10 USD (Bitstamp) paying up to 5 XRP on the XRPL DEX.',
+    category: 'legit',
+    build: (account) =>
+      buildOfferCreate({
+        account,
+        takerGets: xrpToDrops('5'),
+        takerPays: { currency: 'USD', issuer: BITSTAMP_USD_ISSUER, value: '10' },
+      }),
+  },
+  {
+    id: 'trustSet',
+    label: 'TrustSet (trustline)',
+    description: 'Open a 1000 USD trustline to the Bitstamp issuer.',
+    category: 'legit',
+    build: (account) =>
+      buildTrustSet({ account, currency: 'USD', issuer: BITSTAMP_USD_ISSUER, value: '1000' }),
+  },
+  {
+    id: 'adv-partial-payment',
+    label: '⚠ Adversarial — partial payment (no DeliverMin)',
+    description:
+      'Payment with tfPartialPayment set and a large SendMax but no DeliverMin. Destination is you.',
+    category: 'adversarial',
+    expectedWalletBehavior:
+      'Wallet must warn (partial payment, no minimum delivery) or reject; Amount is a ceiling, not guaranteed.',
+    build: (account) => ({
+      ...buildPayment({ account, destination: account, xrp: '1' }),
+      Flags: TF_PARTIAL_PAYMENT,
+      SendMax: xrpToDrops('1000'),
+    }),
+  },
+  {
+    id: 'adv-hidden-paths',
+    label: '⚠ Adversarial — hidden Paths',
+    description: 'Payment carrying a custom Paths array that reroutes how value is sourced. Destination is you.',
+    category: 'adversarial',
+    expectedWalletBehavior: 'Wallet must show that custom Paths are present.',
+    build: (account) => ({
+      ...buildPayment({ account, destination: account, xrp: '1' }),
+      SendMax: { currency: 'USD', issuer: BITSTAMP_USD_ISSUER, value: '5' },
+      Paths: [
+        [{ currency: 'USD', issuer: BITSTAMP_USD_ISSUER }, { currency: 'XRP' }],
+      ],
+    }),
+  },
+]
+
+export function getRippleExample(id: string): RippleExample | undefined {
+  return rippleExamples.find((example) => example.id === id)
+}

--- a/vultisig-playground/src/components/ripple/rippleTransactions.ts
+++ b/vultisig-playground/src/components/ripple/rippleTransactions.ts
@@ -1,0 +1,126 @@
+// Raw XRPL transaction builders — plain JSON objects, no signing, no network.
+// Account is filled by the caller from the connected address.
+// XrplTransaction covers the wallet sanitizer allowlist (Payment, OfferCreate, OfferCancel,
+// TrustSet); the builders below cover the subset the panel exercises (no OfferCancel builder).
+
+const DROPS_PER_XRP = 1_000_000n
+const XRP_DECIMALS = 6
+const XRP_AMOUNT_PATTERN = /^\d+(\.\d+)?$/
+
+export interface IssuedAmount {
+  currency: string
+  issuer: string
+  value: string
+}
+
+export type XrplAmount = string | IssuedAmount
+
+export interface XrplPayment {
+  TransactionType: 'Payment'
+  Account: string
+  Destination: string
+  Amount: XrplAmount
+  DestinationTag?: number
+  SendMax?: XrplAmount
+  DeliverMin?: XrplAmount
+  Flags?: number
+  Paths?: unknown[]
+}
+
+export interface XrplOfferCreate {
+  TransactionType: 'OfferCreate'
+  Account: string
+  TakerGets: XrplAmount
+  TakerPays: XrplAmount
+}
+
+export interface XrplOfferCancel {
+  TransactionType: 'OfferCancel'
+  Account: string
+  OfferSequence: number
+}
+
+export interface XrplTrustSet {
+  TransactionType: 'TrustSet'
+  Account: string
+  LimitAmount: IssuedAmount
+}
+
+export type XrplTransaction = XrplPayment | XrplOfferCreate | XrplOfferCancel | XrplTrustSet
+
+// String-based to avoid float precision loss on drops. Truncates beyond 6dp after validation.
+export function xrpToDrops(xrp: string): string {
+  const trimmed = xrp.trim()
+  if (!XRP_AMOUNT_PATTERN.test(trimmed)) {
+    throw new Error(`Invalid XRP amount: ${xrp}`)
+  }
+  const [whole, frac = ''] = trimmed.split('.')
+  const fracPadded = (frac + '0'.repeat(XRP_DECIMALS)).slice(0, XRP_DECIMALS)
+  const drops = BigInt(whole || '0') * DROPS_PER_XRP + BigInt(fracPadded || '0')
+  return drops.toString()
+}
+
+export interface PaymentParams {
+  account: string
+  destination: string
+  xrp: string
+  destinationTag?: number
+}
+
+export function buildPayment({ account, destination, xrp, destinationTag }: PaymentParams): XrplPayment {
+  const tx: XrplPayment = {
+    TransactionType: 'Payment',
+    Account: account,
+    Destination: destination,
+    Amount: xrpToDrops(xrp),
+  }
+  if (destinationTag !== undefined) tx.DestinationTag = destinationTag
+  return tx
+}
+
+export interface SelfSwapParams {
+  account: string
+  deliverXrp: string
+  sendMaxXrp: string
+}
+
+// Cross-currency-style Payment where Destination === Account.
+export function buildSelfSwapPayment({ account, deliverXrp, sendMaxXrp }: SelfSwapParams): XrplPayment {
+  return {
+    TransactionType: 'Payment',
+    Account: account,
+    Destination: account,
+    Amount: xrpToDrops(deliverXrp),
+    SendMax: xrpToDrops(sendMaxXrp),
+  }
+}
+
+export interface OfferCreateParams {
+  account: string
+  takerGets: XrplAmount
+  takerPays: XrplAmount
+}
+
+export function buildOfferCreate({ account, takerGets, takerPays }: OfferCreateParams): XrplOfferCreate {
+  return {
+    TransactionType: 'OfferCreate',
+    Account: account,
+    TakerGets: takerGets,
+    TakerPays: takerPays,
+  }
+}
+
+export interface TrustSetParams {
+  account: string
+  currency: string
+  issuer: string
+  value: string
+}
+
+export function buildTrustSet({ account, currency, issuer, value }: TrustSetParams): XrplTrustSet {
+  return {
+    TransactionType: 'TrustSet',
+    Account: account,
+    LimitAmount: { currency, issuer, value },
+  }
+}

--- a/vultisig-playground/src/components/ripple/types.ts
+++ b/vultisig-playground/src/components/ripple/types.ts
@@ -1,0 +1,6 @@
+export interface RippleProvider {
+  getAddress: () => Promise<{ address: string }>
+  getPublicKey: () => Promise<{ address: string; publicKey: string }>
+  signTransaction: (params: { transaction: Record<string, unknown> }) => Promise<{ signature: string }>
+  submitTransaction: (params: { transaction: Record<string, unknown> }) => Promise<{ hash: string }>
+}

--- a/vultisig-playground/src/hooks/useProviderMethods.ts
+++ b/vultisig-playground/src/hooks/useProviderMethods.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { tronMethodMapping } from '../components/tron/methodMapping'
 import { tonMethodMapping } from '../components/ton/methodMapping'
 import { cardanoMethodMapping } from '../components/cardano/methodMapping'
+import { rippleMethodMapping } from '../components/ripple/methodMapping'
 
 export function useProviderMethods(providerName: string) {
   const [methods, setMethods] = useState<string[]>([])
@@ -29,6 +30,15 @@ export function useProviderMethods(providerName: string) {
     if (providerName === 'cardano') {
       if (window.cardano?.vultisig) {
         setMethods(Object.keys(cardanoMethodMapping))
+      } else {
+        setMethods([])
+      }
+      return
+    }
+
+    if (providerName === 'ripple') {
+      if (window.vultisig?.xrpl) {
+        setMethods(Object.keys(rippleMethodMapping))
       } else {
         setMethods([])
       }

--- a/vultisig-playground/src/pages/ProviderPlayground.tsx
+++ b/vultisig-playground/src/pages/ProviderPlayground.tsx
@@ -33,6 +33,9 @@ function ProviderPlayground() {
       const tonProvider = window.vultisig.ton as { tonconnect?: unknown } | undefined
       return tonProvider?.tonconnect || null
     }
+    if (provider === 'ripple') {
+      return window.vultisig.xrpl ?? null
+    }
     return (window.vultisig as Record<string, unknown>)[provider] || null
   }
 


### PR DESCRIPTION
## What
Adds a working XRPL/Ripple dApp panel to vultisig-playground. The XRP tab previously rendered nothing (`ripple/methodMapping.tsx` was empty and the provider was looked up under the wrong key).

- Wires `provider === 'ripple'` to the wallet's `window.vultisig.xrpl` object API in `ProviderPlayground` + `useProviderMethods`, mirroring the existing `ton`/`cardano` special-cases.
- **GetAddress** — `getAddress()` / `getPublicKey()`.
- **SignTransaction** — editable raw XRPL JSON with grouped example payloads; "Sign only" (no broadcast, default) vs "Sign & submit" (danger-styled).
- Example payloads built as plain JSON (no new deps): native Payment, self cross-currency Payment, OfferCreate, TrustSet.

## Adversarial (QA) examples
Two labeled adversarial cases reproduce the XRPL confirmation-integrity gap (a dApp-supplied field that gets signed but isn't shown on the confirmation screen):

- **⚠ partial payment (no DeliverMin)** — `Payment` with `tfPartialPayment` + large `SendMax`, no `DeliverMin`.
- **⚠ hidden Paths** — `Payment` carrying a custom `Paths` array.

Each shows an "Expected wallet behavior" note so a dev can compare it to what the wallet actually displays. All adversarial and default payloads target the connected account (self) — no third-party fund destinations.

Tracks: vultisig-windows#4595, vultisig-ios#5081, vultisig-android#5555.

## Verification
- `eslint .` — 0 errors (7 pre-existing warnings, unrelated)
- `vite build` — passes
- `tsc --noEmit` — no new errors in changed files (pre-existing bch/solana/tron errors untouched)

## Manual smoke test (needs the Vultisig extension + a vault)
- Connect XRP; **GetAddress** returns the vault address (and public key with the checkbox).
- **SignTransaction → native payment**: the wallet shows the correct destination and amount.
- **⚠ partial payment**: check whether the wallet warns/rejects the tfPartialPayment (no DeliverMin) case — this is the repro of the tracked issues.
- **⚠ hidden Paths**: check whether the wallet surfaces that custom Paths are present.